### PR TITLE
[fix] Multi Binding 일 때 case 누락 문제를 해결합니다

### DIFF
--- a/Sources/AutoCodableMacros/AutoCodableMacro.swift
+++ b/Sources/AutoCodableMacros/AutoCodableMacro.swift
@@ -45,62 +45,67 @@ public struct AutoCodableMacro: MemberMacro, ExtensionMacro {
                 continue
             }
             
-            /// static 제거
+            /// static 제외
             if variable.modifiers.contains(where: { $0.name.text == "static" }) {
                 continue
             }
             
-            /// 변수 이름 추출
-            guard let binding = variable.bindings.first,
-                  let identifier = binding.pattern.as(IdentifierPatternSyntax.self)
-            else {
-                continue
-            }
-            
-            /// Swift 프로퍼티 이름
-            /// ex)  userProfileURL
-            let propertyName = identifier.identifier.text
-            
-            /// JSON key 이름
-            /// 기본값은 propertyName와 동일
-            var codingKey = propertyName
-            
-            // MARK: - Codable attribute 확인
-            /// 프로퍼티에 붙은 attribute 검사
-            /// ex) @CodableKey(name: "user_profile_url")
-            for attr in variable.attributes {
+            /// Swift에서는 `var a, b: Int` 처럼 하나의 변수 선언에 여러 프로퍼티가 포함될 수 있으므로 bindings 전체를 순회합니다
+            for binding in variable.bindings {
                 
-                guard let attribute = attr.as(AttributeSyntax.self) else {
+                // computed property 제외
+                if binding.accessorBlock != nil {
                     continue
                 }
                 
-                /// attribute 이름
-                let name = attribute.attributeName.description
-                    .trimmingCharacters(in: .whitespaces)
+                guard let identifier = binding.pattern.as(IdentifierPatternSyntax.self) else {
+                    continue
+                }
                 
-                /// CodableKey attribute 발견시
-                if name == "CodableKey" {
+                /// Swift 프로퍼티 이름
+                /// ex)  userProfileURL
+                let propertyName = identifier.identifier.text
+                
+                /// JSON key 이름
+                /// 기본값은 propertyName와 동일
+                var codingKey = propertyName
+                
+                // MARK: - Codable attribute 확인
+                /// 프로퍼티에 붙은 attribute 검사
+                /// ex) @CodableKey(name: "user_profile_url")
+                for attr in variable.attributes {
                     
-                    /// attribute argument 목록
-                    /// ex) name: "user_profile_url"
-                    if let arguments = attribute.arguments?.as(LabeledExprListSyntax.self),
-                       let first = arguments.first {
-                        
-                        /// JSON key 문자열 추출
-                        codingKey = first.expression.description
-                            .replacingOccurrences(of: "\"", with: "")
+                    guard let attribute = attr.as(AttributeSyntax.self) else {
+                        continue
                     }
                     
+                    /// attribute 이름
+                    let name = attribute.attributeName.description
+                        .trimmingCharacters(in: .whitespaces)
+                    
+                    /// CodableKey attribute 발견시
+                    if name == "CodableKey" {
+                        
+                        /// attribute argument 목록
+                        /// ex) name: "user_profile_url"
+                        if let arguments = attribute.arguments?.as(LabeledExprListSyntax.self),
+                           let first = arguments.first {
+                            
+                            /// JSON key 문자열 추출
+                            codingKey = first.expression.description
+                                .replacingOccurrences(of: "\"", with: "")
+                        }
+                    }
                 }
-            }
-            
-            // MARK: - Case 생성
-            if codingKey == propertyName {
-                /// case name
-                cases.append("    case \(propertyName)")
-            } else {
-                /// case userProfileURL = "user_profile_url"
-                cases.append("    case \(propertyName) = \"\(codingKey)\"")
+                
+                // MARK: - Case 생성
+                if codingKey == propertyName {
+                    /// case name
+                    cases.append("    case \(propertyName)")
+                } else {
+                    /// case userProfileURL = "user_profile_url"
+                    cases.append("    case \(propertyName) = \"\(codingKey)\"")
+                }
             }
         }
         

--- a/Tests/AutoCodableTests/AutoCodableTests.swift
+++ b/Tests/AutoCodableTests/AutoCodableTests.swift
@@ -90,4 +90,90 @@ final class AutoCodableTests: XCTestCase {
             macros: testMacros
         )
     }
+    
+    func test_multi_binding_프로퍼티는_모두_CodingKeys에_포함된다() {
+        assertMacroExpansion(
+            """
+            @AutoCodable
+            struct Person {
+                var a, b: Int
+            }
+            """,
+            expandedSource:
+            """
+            struct Person {
+                var a, b: Int
+            
+                private enum CodingKeys: String, CodingKey {
+                    case a
+                    case b
+                }
+            }
+            
+            extension Person: Codable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+    
+    func test_computed_property는_CodingKeys에서_제외된다() {
+        assertMacroExpansion(
+            """
+            @AutoCodable
+            struct Person {
+                let name: String
+            
+                var upperNamr: String {
+                    name.uppercased()
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct Person {
+                let name: String
+
+                var upperNamr: String {
+                    name.uppercased()
+                }
+
+                private enum CodingKeys: String, CodingKey {
+                    case name
+                }
+            }
+            
+            extension Person: Codable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+    
+    func test_static_property는_CodingKeys에서_제외된다() {
+        assertMacroExpansion(
+            """
+            @AutoCodable
+            struct Person {
+                let name: String
+                static var cache: String
+            }
+            """,
+            expandedSource:
+            """
+            struct Person {
+                let name: String
+                static var cache: String
+
+                private enum CodingKeys: String, CodingKey {
+                    case name
+                }
+            }
+
+            extension Person: Codable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
 }


### PR DESCRIPTION
<!-- PR 제목 컨벤션: [이슈 라벨] 작업한 내용 요약 -->

## 💡 PR 유형
<!-- 해당하는 유형에 "x"를 입력하세요. -->
- [ ] Feature: 기능 추가
- [x] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [x] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정
- [ ] CI: CI/CD 및 GitHub Actions 작업 및 수정

## ✏️ 변경 사항
<!-- 이 PR에서 작업한 내용을 간단히 요약해주세요. -->
- computed property가 `CodingKeys`에 포함되던 문제 해결
- multi-binding (`let a, b: Int`) 선언을 올바르게 처리하도록 문제 해결
- `static` property가 `CodingKeys`에 포함되던 문제 수정
- 위 동작을 검증하기 위한 테스트 코드 추가

```swift
// Computed property는 저장 프로퍼티가 아니기 때문에 `CodingKeys`에 포함되면 안 됩니다.
@AutoCodable
struct User {
    let firstName: String
    let lastName: String

    var fullName: String {
        "\(firstName) \(lastName)"
    }
}
// 기대 결과
private enum CodingKeys: String, CodingKey {
    case firstName
    case lastName
}

// 한 줄에서 여러 프로퍼티가 선언된 경우입니다.
@AutoCodable
struct User {
    let name, email: String
}
// 기대 결과
private enum CodingKeys: String, CodingKey {
    case name
    case email
}

// static 프로퍼티는 인스턴스 데이터가 아니기 때문에 Codable 대상이 아닙니다.
@AutoCodable
struct User {
    static let tableName = "users"

    let id: Int
    let name: String
}
// 기대 결과
private enum CodingKeys: String, CodingKey {
    case id
    case name
}
```

## 🚨 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 여러 개인 경우 쉼표로 구분하세요. -->
- close #3

## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## ✅ 체크리스트
<!-- 꼭 모두 체크하고 PR을 생성해주세요. -->
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 여기에 적어주세요. -->
<!-- 코드 리뷰를 받고 싶은 코드나, 설명하고 싶은 코드가 있다면 적어주세요. -->